### PR TITLE
the fix for DOCS-1994

### DIFF
--- a/devplatform/2.0/installation/install_engine.dita
+++ b/devplatform/2.0/installation/install_engine.dita
@@ -114,7 +114,7 @@ stack@helionce-deployer:~/helion/hos/ansible$ ansible-playbook -vvv -i hosts/loc
  
 [ OUTPUT TRIMMED ]</codeblock></li>
             <li>Run the Config Processor Play
-              <codeblock>stack@helionce-deployer:~/helion/hos/ansible$ ansible-playbook -vvv -i hosts/localhost config-processor-run.yml
+              <codeblock>stack@helionce-deployer:~/helion/hos/ansible$ ansible-playbook -vvv -i hosts/localhost config-processor-run.yml -e encrypt="" -e rekey=""
  
 [ OUTPUT TRIMMED ]</codeblock></li>
             <li>Run the Ready Deployment Play


### PR DESCRIPTION
adding params to `ansible-playbook -vvv -i hosts/localhost config-processor-run.yml` make it skip unnecessary -- and confusing to the user -- prompts.
