### PR TITLE
Adding recommended flavor of 3 (Medium) for messaging-deployer

### DIFF
--- a/devplatform/2.0/installation/cloud/cloud_messaging.dita
+++ b/devplatform/2.0/installation/cloud/cloud_messaging.dita
@@ -59,7 +59,7 @@
         <dlentry>
           <dt>deployer_flavor (optional)</dt>
           <dd>The flavor ID to use for the deployer instance. Default value: 4 (which is
-            Large).</dd>
+            Large).  Recommended flavor: 3 (Medium)</dd>
         </dlentry>
         <dlentry>
           <dt>deployer_name (optional)</dt>


### PR DESCRIPTION
There is bug when flavor is set to something greater than 3, disk resize
will not provide enough space for the root partition.  In the meantime
it is recommended for the user to use a flavor of 3 (Medium) for the
messaging-deployer VM.
