### PR TITLE
Revert "DOCS-1963 manifest.yml should use "memory:" instead of "mem:""

### DIFF
--- a/devplatform/2.0/helion/admin/console/app-store.dita
+++ b/devplatform/2.0/helion/admin/console/app-store.dita
@@ -64,7 +64,7 @@ apps:
   src: https://github.com/Helion-Apps/bugzilla.git
   info: https://github.com/Helion-Apps/bugzilla.git#readme
   icon: https://get.helion.com/store/icon/bugzilla.png
-  memory: 256
+  mem: 256
 
 - name: Django CMS
   id: django-cms
@@ -77,7 +77,7 @@ apps:
   src: https://github.com/Helion-Apps/django-cms.git
   info: https://github.com/Helion-Apps/django-cms.git#readme
   icon: https://get.helion.com/store/icon/django-cms.png
-  memory: 128
+  mem: 128
 
 - name: Node Chat
   id: node-chat
@@ -86,7 +86,7 @@ apps:
   runtime: node
   commit: master
   icon: https://get.helion.com/store/icon/chat.png
-  memory: 64
+  mem: 64
   license: MIT
   src: https://github.com/Helion-Apps/node-chat.git
   info: https://github.com/Helion-Apps/node-chat.git#readme</codeblock>

--- a/devplatform/2.0/helion/user/deploy/buildpack.dita
+++ b/devplatform/2.0/helion/user/deploy/buildpack.dita
@@ -34,7 +34,7 @@ framework:
 <p>To specify the exact buildpack to use for deploying your application,
 set a top-level <codeph>buildpack:</codeph> key in <i>manifest.yml</i> to the URL of the buildpack's Git repository. For example:</p>
 <codeblock>name: myrubyapp
-memory: 256MB
+mem: 256MB
 buildpack: https://github.com/hpcloud/stackato-buildpack-ruby.git</codeblock>
 <p>You can use a specific branch by specifying it at the end of the URL using the following format:</p>
 <codeblock>buildpack: https://github.com/hpcloud/stackato-buildpack-ruby.git#branchname</codeblock>

--- a/devplatform/2.0/helion/user/deploy/languages/java.dita
+++ b/devplatform/2.0/helion/user/deploy/languages/java.dita
@@ -62,12 +62,13 @@ demonstrates a simple Java application using a MySQL service.</p>
 Management Console) to override Application Lifecycle Service defaults.</p>
       <note type="restriction"> CATALINA_OPTS settings cannot be modified without restaging. Applications must be
         re-pushed with new settings to apply changes.</note>
-<p>Application Lifecycle Service sets the CATALINA_OPTS environment variable for applications using
-        Tomcat automatically, based on the <codeph>memory:</codeph> value specified for application
-        instances. Application Lifecycle Service will always leave at least 64MB for the heap, but
-        will otherwise reserves up to 96MB for overhead, that is for the code of the JVM itself, for
-        additional libraries loaded via JNI, for additional processes to run in the background, and
-        for the JVM permanent pool.</p>
+<p>Application Lifecycle Service sets the CATALINA_OPTS environment variable for applications
+using Tomcat automatically, based on the <codeph>mem:</codeph>
+value specified for application instances. Application Lifecycle Service will always leave at
+least 64MB for the heap, but will otherwise reserves up to 96MB for
+overhead, that is for the code of the JVM itself, for additional
+libraries loaded via JNI, for additional processes to run in the
+background, and for the JVM permanent pool.</p>
 <p>This means, for example, a 128MB application will end up with 64MB for
 the heap and 64MB for overhead, a 160MB application will still have 64MB
 for the heap but 96MB for overhead, and a 512MB application will get a

--- a/devplatform/2.0/helion/user/deploy/manifestyml.dita
+++ b/devplatform/2.0/helion/user/deploy/manifestyml.dita
@@ -77,8 +77,8 @@
               </li>
             </ul></li>
 <li>
-            <xref type="section" href="#topic20922/mem">memory:</xref>
-          </li>
+<xref type="section" href="#topic20922/mem">mem:</xref>
+</li>
 <li>
 <xref type="section" href="#topic20922/disk">disk:</xref>
 </li>
@@ -160,13 +160,13 @@ for each app are contained. For example:</p>
     framework:
       name: spring
     instances: 1
-    memory: 512
+    mem: 512
   worker:
     name: springweb-helper
     framework:
       name: node
     instances: 1
-    memory: 64</codeblock>
+    mem: 64</codeblock>
 <p>Here the two keys <codeph>web:</codeph> and <codeph>worker:</codeph> match subdirectories (named <codeph>web</codeph> and
 <codeph>worker</codeph>) of the directory containing the
 <i>manifest.yml</i> file.</p>
@@ -178,7 +178,7 @@ directory along with the <i>manifest.yml</i> file:</p>
     framework:
       name: spring
     instances: 1
-    memory: 512</codeblock>
+    mem: 512</codeblock>
 </section>
 <section id="depends-on"> <title>depends-on:</title>
 <p>When deploying multiple applications from a single <i>manifest.yml</i> use
@@ -194,13 +194,13 @@ pushed and are running on the server.</p>
     framework:
       name: spring
     instances: 1
-    memory: 512
+    mem: 512
   worker:
     name: springweb-helper
     framework:
       name: node
     instances: 1
-    memory: 64</codeblock>
+    mem: 64</codeblock>
 <p>If an app is stopped or restarted, the process happens in the reverse
 order.</p>
 </section>
@@ -221,7 +221,7 @@ order.</p>
   .:
     name: celery-demo
     buildpack: https://github.com/hpcloud/stackato-buildpack-python.git
-    memory: 128
+    mem: 128
     helion:
       env:
         CELERY_ENV:
@@ -267,7 +267,7 @@ provide a name. The name can also be specified on the command line (eg.
 <p>The Git repository URL for the specific <xref href="buildpack.dita#topic3370">buildpack</xref>
         used to deploy the application. For example:</p>
 <codeblock>  name: java-app
-memory: 512M
+mem: 512M
 buildpack: https://github.com/heroku/heroku-buildpack-java.git</codeblock>
 <p>If unset, Application Lifecycle Service will check to see if the application triggers the
   <codeph>detect</codeph> scripts in any of its <xref href="buildpack.dita#topic3370/built-in-buildpacks" type="section"   >built-in
@@ -475,14 +475,14 @@ requirements:
     - CGI::Application::PSGI
     - Plack::Builder</codeblock>
 </section>
-<section id="mem"> <title>memory:</title>
+<section id="mem"> <title>mem:</title>
 <p>The amount of memory to allocate for the application.</p>
 <p>Syntax: \&lt;int&gt; or \&lt;int&gt;M - Memory in megabytes. eg. 256M</p>
 <p>Syntax: \&lt;int&gt;G or \&lt;float&gt;G - Memory in gigabytes. eg. 1.5G or 2G</p>
 <p>If not specified, user may be prompted during <codeph>helion push</codeph>. Can also be specified on the command line (eg.
 <codeph>helion push --mem 256M</codeph>).</p>
 <p>Example:</p>
-<codeblock>  memory: 64M</codeblock>
+<codeblock>  mem: 64M</codeblock>
 </section>
 
 <section id="disk"> <title>disk:</title> 
@@ -493,7 +493,7 @@ requirements:
 <p>If not specified, 2GB of disk space is allocated. Can also be specified
 on the command line (eg. <codeph>helion push --disk 768M</codeph>).</p>
 <p>Example:</p>
-<codeblock>  memory: 3.5GB</codeblock>
+<codeblock>  mem: 3.5GB</codeblock>
 </section>
 <section id="instances"> <title>instances:</title>
 <p>The number of instances to allocate for the application. If not
@@ -663,12 +663,12 @@ file to be included into <i>manifest.yml</i>.</p>
 <i>manifest.yml</i>:</p>
 <codeblock>  name: example-app
 inherit: parent.yml
-memory: 64M</codeblock>
+mem: 64M</codeblock>
 <p>effect from processing:</p>
 <codeblock>  name: example-app
 env:
   COMPANY: The ABC Company
-memory: 64M</codeblock>
+mem: 64M</codeblock>
 </section>
 <section id="hooks"> <title>hooks:</title>
 <p>Hooks are commands that are run at various point of the staging and

--- a/devplatform/2.0/helion/user/services/data-services.dita
+++ b/devplatform/2.0/helion/user/services/data-services.dita
@@ -116,7 +116,7 @@ for using the <i>manifest.yml</i> file, please see <xref href="../deploy/manifes
 <p>A simple example telling the Application Lifecycle Service Client to request a MySQL database named
 <b>cirrusdb</b>:</p>
 <codeblock>name: cirrus
-memory: 256M
+mem: 256M
 instances: 2
 services:
     cirrusdb: mysql</codeblock>

--- a/devplatform/2.0/helion/user/services/port-service.dita
+++ b/devplatform/2.0/helion/user/services/port-service.dita
@@ -49,7 +49,7 @@
           href="../deploy/manifestyml.dita#topic20922/services"><b>services</b></xref> block. For
         example:</p>
 <codeblock>name: port-test
-memory: 256
+mem: 256
 services:
   my-port: harbor</codeblock>
 <p>This creates a TCP port tunnel which the application can access on the


### PR DESCRIPTION
Reverts hphelion/documentation#32
